### PR TITLE
Add #to_s method to rails version

### DIFF
--- a/lib/underscore-rails.rb
+++ b/lib/underscore-rails.rb
@@ -2,7 +2,7 @@ require "underscore-rails/version"
 
 module Underscore
   module Rails
-    if defined?(::Rails) and ::Rails.version >= "3.1"
+    if defined?(::Rails) and ::Rails.version.to_s >= "3.1"
       class Rails::Engine < ::Rails::Engine
         # this class enables the asset pipeline
       end


### PR DESCRIPTION
`Rails.version` now returns an instance of `Gem::Version`
See https://github.com/rails/rails/pull/8501

This results in the following exception:

/Users/wouterw/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/underscore-rails-6e01769de4b2/lib/underscore-rails.rb:5:in `>=': comparison of Gem::Version with String failed (ArgumentError)
